### PR TITLE
116 log timestamp

### DIFF
--- a/tests/validate_fixity/test_fixity_validation_log.py
+++ b/tests/validate_fixity/test_fixity_validation_log.py
@@ -27,19 +27,20 @@ class MyTestCase(unittest.TestCase):
 
         # Verifies the log has the correct values.
         result = csv_to_list(os.path.join(acc_dir, f"fixity_validation_log_{date.today().strftime('%Y-%m-%d')}.csv"))
-        expected = [['Status', 'Collection', 'Accession', 'Accession_Path', 'Fixity_Type', 'Fixity', 'Valid', 'Result'],
+        expected = [['Status', 'Collection', 'Accession', 'Accession_Path', 'Fixity_Type', 'Fixity',
+                     'Valid', 'Valid_Time', 'Result'],
                     ['backlogged', 'harg_ms1234 papers', '2021_12_er',
                      os.path.join(acc_dir, 'backlogged', 'harg_ms1234 papers', '2021_12_er'),
-                     'Bag', '2021_12_er_bag', 'BLANK', 'BLANK'],
+                     'Bag', '2021_12_er_bag', 'BLANK', 'BLANK', 'BLANK'],
                     ['backlogged', 'harg_ms1234 papers', '2021_345_ER',
                      os.path.join(acc_dir, 'backlogged', 'harg_ms1234 papers', '2021_345_ER'),
-                     'Bag', '2021_345_ER_bag', 'BLANK', 'BLANK'],
+                     'Bag', '2021_345_ER_bag', 'BLANK', 'BLANK', 'BLANK'],
                     ['closed', 'harg_ms1000 papers', '2001_01_er',
                      os.path.join(acc_dir, 'closed', 'harg_ms1000 papers', '2001_01_er'),
-                     'Bag', '2001_01_er_bag', 'BLANK', 'BLANK'],
+                     'Bag', '2001_01_er_bag', 'BLANK', 'BLANK', 'BLANK'],
                     ['closed', 'harg_ms2000 papers', '2002_02_er',
                      os.path.join(acc_dir, 'closed', 'harg_ms2000 papers', '2002_02_er'),
-                     'Bag', '2002_02_er_bag', 'BLANK', 'BLANK']]
+                     'Bag', '2002_02_er_bag', 'BLANK', 'BLANK', 'BLANK']]
         self.assertEqual(result, expected, "Problem with test for acc_bag")
 
     def test_acc_zip(self):
@@ -50,19 +51,20 @@ class MyTestCase(unittest.TestCase):
 
         # Verifies the log has the correct values.
         result = csv_to_list(os.path.join(acc_dir, f"fixity_validation_log_{date.today().strftime('%Y-%m-%d')}.csv"))
-        expected = [['Status', 'Collection', 'Accession', 'Accession_Path', 'Fixity_Type', 'Fixity', 'Valid', 'Result'],
+        expected = [['Status', 'Collection', 'Accession', 'Accession_Path', 'Fixity_Type', 'Fixity',
+                     'Valid', 'Valid_Time', 'Result'],
                     ['backlogged', 'rbrl123', '2010-01-er',
                      os.path.join(acc_dir, 'backlogged', 'rbrl123', '2010-01-er'),
-                     'Zip', '2010-01-er_zip_md5.txt', 'BLANK', 'BLANK'],
+                     'Zip', '2010-01-er_zip_md5.txt', 'BLANK', 'BLANK', 'BLANK'],
                     ['backlogged', 'rbrl123', '2010-02-er',
                      os.path.join(acc_dir, 'backlogged', 'rbrl123', '2010-02-er'),
-                     'Zip', '2010-02-er_zip_md5.txt', 'BLANK', 'BLANK'],
+                     'Zip', '2010-02-er_zip_md5.txt', 'BLANK', 'BLANK', 'BLANK'],
                     ['backlogged', 'rbrl456abc', '2010-06-er',
                      os.path.join(acc_dir, 'backlogged', 'rbrl456abc', '2010-06-er'),
-                     'Zip', '2010-06-er_zip_md5.txt', 'BLANK', 'BLANK'],
+                     'Zip', '2010-06-er_zip_md5.txt', 'BLANK', 'BLANK', 'BLANK'],
                     ['closed', 'rbrl333', 'no-acc-num',
                      os.path.join(acc_dir, 'closed', 'rbrl333', 'no-acc-num'),
-                     'Zip', 'no-acc-num_zip_md5.txt', 'BLANK', 'BLANK']]
+                     'Zip', 'no-acc-num_zip_md5.txt', 'BLANK', 'BLANK', 'BLANK']]
         self.assertEqual(result, expected, "Problem with test for acc_zip")
 
     def test_extra_status(self):
@@ -73,9 +75,10 @@ class MyTestCase(unittest.TestCase):
 
         # Verifies the log has the correct values.
         result = csv_to_list(os.path.join(acc_dir, f"fixity_validation_log_{date.today().strftime('%Y-%m-%d')}.csv"))
-        expected = [['Status', 'Collection', 'Accession', 'Accession_Path', 'Fixity_Type', 'Fixity', 'Valid', 'Result'],
+        expected = [['Status', 'Collection', 'Accession', 'Accession_Path', 'Fixity_Type', 'Fixity',
+                     'Valid', 'Valid_Time', 'Result'],
                     ['closed', 'rbrl333', 'no-acc-num', os.path.join(acc_dir, 'closed', 'rbrl333', 'no-acc-num'),
-                     'Bag', 'no-acc-num_bag', 'BLANK', 'BLANK']]
+                     'Bag', 'no-acc-num_bag', 'BLANK', 'BLANK', 'BLANK']]
         self.assertEqual(result, expected, "Problem with test for extra_status")
 
     def test_no_acc(self):
@@ -86,15 +89,16 @@ class MyTestCase(unittest.TestCase):
 
         # Verifies the log has the correct values.
         result = csv_to_list(os.path.join(acc_dir, f"fixity_validation_log_{date.today().strftime('%Y-%m-%d')}.csv"))
-        expected = [['Status', 'Collection', 'Accession', 'Accession_Path', 'Fixity_Type', 'Fixity', 'Valid', 'Result'],
+        expected = [['Status', 'Collection', 'Accession', 'Accession_Path', 'Fixity_Type', 'Fixity',
+                     'Valid', 'Valid_Time', 'Result'],
                     ['backlogged', 'ua22-333 records', '2022-1-er',
                      os.path.join(acc_dir, 'backlogged', 'ua22-333 records', '2022-1-er'),
-                     'Bag', '2022-1-er_bag', 'BLANK', 'BLANK'],
+                     'Bag', '2022-1-er_bag', 'BLANK', 'BLANK', 'BLANK'],
                     ['backlogged', 'ua22-333 records', 'Appraisal copy',
                      os.path.join(acc_dir, 'backlogged', 'ua22-333 records', 'Appraisal copy'),
-                     'BLANK', 'BLANK', 'Skipped', 'Not an accession'],
+                     'BLANK', 'BLANK', 'Skipped', 'BLANK', 'Not an accession'],
                     ['closed', 'harg1234', 'access', os.path.join(acc_dir, 'closed', 'harg1234', 'access'),
-                     'BLANK', 'BLANK', 'Skipped', 'Not an accession']]
+                     'BLANK', 'BLANK', 'Skipped', 'BLANK', 'Not an accession']]
         self.assertEqual(result, expected, "Problem with test for no_acc")
 
     def test_no_fixity(self):
@@ -105,11 +109,12 @@ class MyTestCase(unittest.TestCase):
 
         # Verifies the log has the correct values.
         result = csv_to_list(os.path.join(acc_dir, f"fixity_validation_log_{date.today().strftime('%Y-%m-%d')}.csv"))
-        expected = [['Status', 'Collection', 'Accession', 'Accession_Path', 'Fixity_Type', 'Fixity', 'Valid', 'Result'],
+        expected = [['Status', 'Collection', 'Accession', 'Accession_Path', 'Fixity_Type', 'Fixity',
+                     'Valid', 'Valid_Time', 'Result'],
                     ['closed', 'rbrl333', '2002_02_er', os.path.join(acc_dir, 'closed', 'rbrl333', '2002_02_er'),
-                     'BLANK', 'BLANK', 'False', 'No fixity information'],
+                     'BLANK', 'BLANK', 'False', 'BLANK', 'No fixity information'],
                     ['closed', 'rbrl333', 'no-acc-num', os.path.join(acc_dir, 'closed', 'rbrl333', 'no-acc-num'),
-                     'BLANK', 'BLANK', 'False', 'No fixity information']]
+                     'BLANK', 'BLANK', 'False', 'BLANK', 'No fixity information']]
         self.assertEqual(result, expected, "Problem with test for no_acc")
 
 

--- a/tests/validate_fixity/test_script_validate_fixity.py
+++ b/tests/validate_fixity/test_script_validate_fixity.py
@@ -1,8 +1,11 @@
 """
 Tests for the script validate_fixity.py, which validates accession fixity, updates the logs, and makes a report.
+
+Note: the fixity validation log includes a timestamp to a minute, so if that fails, check if it is just off by minute.
+That could mean it is working fine but the clock ticked over 1 minute between making the output and testing it.
 """
 import csv
-from datetime import date
+from datetime import date, datetime
 import os
 import pandas as pd
 import shutil
@@ -71,22 +74,24 @@ class MyTestCase(unittest.TestCase):
 
         # Verifies the contents of the fixity validation log are correct.
         result = csv_to_list(os.path.join(input_directory, f"fixity_validation_log_{today}.csv"))
-        expected = [['Status', 'Collection', 'Accession', 'Accession_Path', 'Fixity_Type', 'Fixity', 'Valid', 'Result'],
+        expected = [['Status', 'Collection', 'Accession', 'Accession_Path', 'Fixity_Type', 'Fixity',
+                     'Valid', 'Valid_Time', 'Result'],
                     ['backlogged', 'test_001', '2023_test001_002_er',
                      os.path.join(input_directory, 'backlogged', 'test_001', '2023_test001_002_er'),
-                     'Bag', '2023_test001_002_er_bag', 'True', 'Valid'],
+                     'Bag', '2023_test001_002_er_bag', 'True', datetime.now().strftime('%Y-%m-%d %H:%M'), 'Valid'],
                     ['backlogged', 'test_001', '2023_test001_004_er',
                      os.path.join(input_directory, 'backlogged', 'test_001', '2023_test001_004_er'),
-                     'Bag', '2023_test001_004_er_bag', 'False',
+                     'Bag', '2023_test001_004_er_bag', 'False', datetime.now().strftime('%Y-%m-%d %H:%M'),
                      'Bag validation failed: data\\CD_2\\File2.txt md5 validation failed: '
                      'expected="00a0aaaa0aa0a00ab00ad0a000aa00a0" found="85c8fbcb2ff1d73cb94ed9c355eb20d5"'],
                     ['backlogged', 'test_005', '2023_test005_001_er',
                      os.path.join(input_directory, 'backlogged', 'test_005', '2023_test005_001_er'),
-                     'Zip', '2023_test005_001_er_zip_md5.txt', 'False',
+                     'Zip', '2023_test005_001_er_zip_md5.txt', 'False', datetime.now().strftime('%Y-%m-%d %H:%M'),
                      'Fixity changed from xxx00f6a775ac9bd804c276c889fxxx to 06000f6a775ac9bd804c276c889f6bc7.'],
                     ['closed', 'test_123', '2023_test123_001_er',
                      os.path.join(input_directory, 'closed', 'test_123', '2023_test123_001_er'),
-                     'Zip', '2023_test123_001_er_zip_md5.txt', 'True', 'Valid']]
+                     'Zip', '2023_test123_001_er_zip_md5.txt', 'True', datetime.now().strftime('%Y-%m-%d %H:%M'),
+                     'Valid']]
         self.assertEqual(result, expected, 'Problem with test for mix, validation report')
 
         # Verifies the contents of the preservation log for 2023_test001_002_er have been updated.
@@ -135,15 +140,16 @@ class MyTestCase(unittest.TestCase):
         # Makes the fixity validation log, as if the first two accessions had validated when running the script earlier.
         # It is made by the test instead of stored in the repo so the date in the filename will be correct.
         coll_path = os.path.join(input_directory, 'backlogged', 'coll_2023')
-        rows = [['Status', 'Collection', 'Accession', 'Accession_Path', 'Fixity_Type', 'Fixity', 'Valid', 'Result'],
+        rows = [['Status', 'Collection', 'Accession', 'Accession_Path', 'Fixity_Type', 'Fixity',
+                 'Valid', 'Valid_Time', 'Result'],
                 ['backlogged', 'coll_2023', '2023_test001_001_er', os.path.join(coll_path, '2023_test001_001_er'),
-                 'Bag', '2023_test001_001_er_bag', 'True', 'Valid'],
+                 'Bag', '2023_test001_001_er_bag', 'True', '2000-01-01 12:12', 'Valid'],
                 ['backlogged', 'coll_2023', '2023_test001_005_er', os.path.join(coll_path, '2023_test001_005_er'),
-                 'Bag', '2023_test001_005_er_bag', 'False', 'Bag validation failed'],
+                 'Bag', '2023_test001_005_er_bag', 'False', '2000-01-01 12:13', 'Bag validation failed'],
                 ['backlogged', 'coll_2023', '2023_test004_002_er', os.path.join(coll_path, '2023_test004_002_er'),
-                 'Zip', '2023_test004_002_er_zip_md5.txt', None, None],
+                 'Zip', '2023_test004_002_er_zip_md5.txt', None, None, None],
                 ['backlogged', 'coll_2023', '2023_test005_004_er', os.path.join(coll_path, '2023_test005_004_er'),
-                 'Zip', '2023_test005_004_er_zip_md5.txt', None, None]]
+                 'Zip', '2023_test005_004_er_zip_md5.txt', None, None, None]]
         log_path = os.path.join(input_directory, f"fixity_validation_log_{date.today().strftime('%Y-%m-%d')}.csv")
         with open(log_path, 'w', newline='') as open_log:
             log_writer = csv.writer(open_log)
@@ -163,15 +169,17 @@ class MyTestCase(unittest.TestCase):
 
         # Verifies the contents of the fixity validation log are correct.
         result = csv_to_list(os.path.join(input_directory, f"fixity_validation_log_{today}.csv"))
-        expected = [['Status', 'Collection', 'Accession', 'Accession_Path', 'Fixity_Type', 'Fixity', 'Valid', 'Result'],
+        expected = [['Status', 'Collection', 'Accession', 'Accession_Path', 'Fixity_Type', 'Fixity',
+                     'Valid', 'Valid_Time', 'Result'],
                     ['backlogged', 'coll_2023', '2023_test001_001_er', os.path.join(coll_path, '2023_test001_001_er'),
-                     'Bag', '2023_test001_001_er_bag', 'True', 'Valid'],
+                     'Bag', '2023_test001_001_er_bag', 'True', '2000-01-01 12:12', 'Valid'],
                     ['backlogged', 'coll_2023', '2023_test001_005_er', os.path.join(coll_path, '2023_test001_005_er'),
-                     'Bag', '2023_test001_005_er_bag', 'False', 'Bag validation failed'],
+                     'Bag', '2023_test001_005_er_bag', 'False', '2000-01-01 12:13', 'Bag validation failed'],
                     ['backlogged', 'coll_2023', '2023_test004_002_er', os.path.join(coll_path, '2023_test004_002_er'),
-                     'Zip', '2023_test004_002_er_zip_md5.txt', 'True', 'Valid'],
+                     'Zip', '2023_test004_002_er_zip_md5.txt', 'True', datetime.now().strftime('%Y-%m-%d %H:%M'),
+                     'Valid'],
                     ['backlogged', 'coll_2023', '2023_test005_004_er', os.path.join(coll_path, '2023_test005_004_er'),
-                     'Zip', '2023_test005_004_er_zip_md5.txt', 'False',
+                     'Zip', '2023_test005_004_er_zip_md5.txt', 'False', datetime.now().strftime('%Y-%m-%d %H:%M'),
                      'Fixity changed from a1b11111cd111efa111b11c11111d1e1 to d3f13182fa611fcd011f70c42755e9e4.']]
         self.assertEqual(result, expected, 'Problem with test for restart, fixity validation log')
 
@@ -222,15 +230,17 @@ class MyTestCase(unittest.TestCase):
 
         # Verifies the contents of the fixity validation log.
         result = csv_to_list(os.path.join(input_directory, f"fixity_validation_log_{today}.csv"))
-        expected = [['Status', 'Collection', 'Accession', 'Accession_Path', 'Fixity_Type', 'Fixity', 'Valid', 'Result'],
+        expected = [['Status', 'Collection', 'Accession', 'Accession_Path', 'Fixity_Type', 'Fixity',
+                     'Valid', 'Valid_Time', 'Result'],
                     ['closed', 'test_001', '2023_test001_001_er',
                      os.path.join(input_directory, 'closed', 'test_001', '2023_test001_001_er'),
-                     'Bag', '2023_test001_001_er_bag', 'True', 'Valid'],
+                     'Bag', '2023_test001_001_er_bag', 'True', datetime.now().strftime('%Y-%m-%d %H:%M'), 'Valid'],
                     ['closed', 'test_004', '2023_test004_003_er',
                      os.path.join(input_directory, 'closed', 'test_004', '2023_test004_003_er'),
-                     'Zip', '2023_test004_003_er_zip_md5.txt', 'True', 'Valid'],
+                     'Zip', '2023_test004_003_er_zip_md5.txt', 'True', datetime.now().strftime('%Y-%m-%d %H:%M'),
+                     'Valid'],
                     ['closed', 'to_skip', 'to_skip', os.path.join(input_directory, 'closed', 'to_skip', 'to_skip'),
-                    'BLANK', 'BLANK', 'Skipped', 'Not an accession']]
+                    'BLANK', 'BLANK', 'Skipped', 'BLANK', 'Not an accession']]
         self.assertEqual(result, expected, 'Problem with test for valid, fixity validation log')
 
         # Verifies the contents of the preservation log for 2023_test001_001_er have been updated.

--- a/tests/validate_fixity/test_update_fixity_validation_log.py
+++ b/tests/validate_fixity/test_update_fixity_validation_log.py
@@ -1,7 +1,11 @@
 """
 Tests for the function update_fixity_validation_log(), which adds the validation result to the log.
 To simplify the tests, information in the logs is abbreviated and may not align with the validation result supplied.
+
+Note: the result includes a timestamp to a minute, so if that fails, check if it is just off by minute.
+That could mean it is working fine but the clock ticked over 1 minute between making the output and testing it.
 """
+from datetime import datetime
 import os
 import pandas as pd
 import unittest
@@ -13,9 +17,10 @@ class MyTestCase(unittest.TestCase):
 
     def setUp(self):
         """Make the dataframe and csv of the log that the tests will update"""
-        row_list = [['closed', 'c1', 'a1-er', 'path\\a1-er', 'Bag', 'a1-er_bag', None, None],
-                    ['closed', 'c1', 'a2-er', 'path\\a2-er', 'Zip', 'a2-er_zip_md5.txt', None, None]]
-        columns_list = ['Status', 'Collection', 'Accession', 'Accession_Path', 'Fixity_Type', 'Fixity', 'Valid', 'Result']
+        row_list = [['closed', 'c1', 'a1-er', 'path\\a1-er', 'Bag', 'a1-er_bag', None, None, None],
+                    ['closed', 'c1', 'a2-er', 'path\\a2-er', 'Zip', 'a2-er_zip_md5.txt', None, None, None]]
+        columns_list = ['Status', 'Collection', 'Accession', 'Accession_Path', 'Fixity_Type', 'Fixity',
+                        'Valid', 'Valid_Time', 'Result']
         self.log_df = pd.DataFrame(row_list, columns=columns_list)
         self.log_df.to_csv('fixity_validation_20241031.csv', index=False)
 
@@ -30,9 +35,12 @@ class MyTestCase(unittest.TestCase):
 
         # Verifies the fixity validation log CSV has the correct values.
         result = csv_to_list('fixity_validation_20241031.csv')
-        expected = [['Status', 'Collection', 'Accession', 'Accession_Path', 'Fixity_Type', 'Fixity', 'Valid', 'Result'],
-                    ['closed', 'c1', 'a1-er', 'path\\a1-er', 'Bag', 'a1-er_bag', 'True', 'Valid'],
-                    ['closed', 'c1', 'a2-er', 'path\\a2-er', 'Zip', 'a2-er_zip_md5.txt', 'BLANK', 'BLANK']]
+        expected = [['Status', 'Collection', 'Accession', 'Accession_Path', 'Fixity_Type', 'Fixity',
+                     'Valid', 'Valid_Time', 'Result'],
+                    ['closed', 'c1', 'a1-er', 'path\\a1-er', 'Bag', 'a1-er_bag',
+                     'True', datetime.now().strftime('%Y-%m-%d %H:%M'), 'Valid'],
+                    ['closed', 'c1', 'a2-er', 'path\\a2-er', 'Zip', 'a2-er_zip_md5.txt',
+                     'BLANK', 'BLANK', 'BLANK']]
         self.assertEqual(result, expected, "Problem with test for one change to the log")
 
     def test_two_changes(self):
@@ -42,9 +50,12 @@ class MyTestCase(unittest.TestCase):
 
         # Verifies the fixity validation log CSV has the correct values.
         result = csv_to_list('fixity_validation_20241031.csv')
-        expected = [['Status', 'Collection', 'Accession', 'Accession_Path', 'Fixity_Type', 'Fixity', 'Valid', 'Result'],
-                    ['closed', 'c1', 'a1-er', 'path\\a1-er', 'Bag', 'a1-er_bag', 'True', 'Valid'],
-                    ['closed', 'c1', 'a2-er', 'path\\a2-er', 'Zip', 'a2-er_zip_md5.txt', 'True', 'Valid']]
+        expected = [['Status', 'Collection', 'Accession', 'Accession_Path', 'Fixity_Type', 'Fixity',
+                     'Valid', 'Valid_Time', 'Result'],
+                    ['closed', 'c1', 'a1-er', 'path\\a1-er', 'Bag', 'a1-er_bag',
+                     'True', datetime.now().strftime('%Y-%m-%d %H:%M'), 'Valid'],
+                    ['closed', 'c1', 'a2-er', 'path\\a2-er', 'Zip', 'a2-er_zip_md5.txt',
+                     'True', datetime.now().strftime('%Y-%m-%d %H:%M'), 'Valid']]
         self.assertEqual(result, expected, "Problem with test for two changes to the log")
 
     def test_not_valid_bag(self):
@@ -54,9 +65,12 @@ class MyTestCase(unittest.TestCase):
 
         # Verifies the fixity validation log CSV has the correct values.
         result = csv_to_list('fixity_validation_20241031.csv')
-        expected = [['Status', 'Collection', 'Accession', 'Accession_Path', 'Fixity_Type', 'Fixity', 'Valid', 'Result'],
-                    ['closed', 'c1', 'a1-er', 'path\\a1-er', 'Bag', 'a1-er_bag', 'False', 'Payload-Oxum failed.'],
-                    ['closed', 'c1', 'a2-er', 'path\\a2-er', 'Zip', 'a2-er_zip_md5.txt', 'False', 'Bag validation failed.']]
+        expected = [['Status', 'Collection', 'Accession', 'Accession_Path', 'Fixity_Type', 'Fixity',
+                     'Valid', 'Valid_Time', 'Result'],
+                    ['closed', 'c1', 'a1-er', 'path\\a1-er', 'Bag', 'a1-er_bag',
+                     'False', datetime.now().strftime('%Y-%m-%d %H:%M'), 'Payload-Oxum failed.'],
+                    ['closed', 'c1', 'a2-er', 'path\\a2-er', 'Zip', 'a2-er_zip_md5.txt',
+                     'False', datetime.now().strftime('%Y-%m-%d %H:%M'), 'Bag validation failed.']]
         self.assertEqual(result, expected, "Problem with test for not valid, bag error")
 
     def test_not_valid_bag_manifest(self):
@@ -66,9 +80,12 @@ class MyTestCase(unittest.TestCase):
 
         # Verifies the fixity validation log CSV has the correct values.
         result = csv_to_list('fixity_validation_20241031.csv')
-        expected = [['Status', 'Collection', 'Accession', 'Accession_Path', 'Fixity_Type', 'Fixity', 'Valid', 'Result'],
-                    ['closed', 'c1', 'a1-er', 'path\\a1-er', 'Bag', 'a1-er_bag', 'False', '1 bag manifest errors.'],
-                    ['closed', 'c1', 'a2-er', 'path\\a2-er', 'Zip', 'a2-er_zip_md5.txt', 'False', '99 bag manifest errors.']]
+        expected = [['Status', 'Collection', 'Accession', 'Accession_Path', 'Fixity_Type', 'Fixity',
+                     'Valid', 'Valid_Time', 'Result'],
+                    ['closed', 'c1', 'a1-er', 'path\\a1-er', 'Bag', 'a1-er_bag',
+                     'False', datetime.now().strftime('%Y-%m-%d %H:%M'), '1 bag manifest errors.'],
+                    ['closed', 'c1', 'a2-er', 'path\\a2-er', 'Zip', 'a2-er_zip_md5.txt',
+                     'False', datetime.now().strftime('%Y-%m-%d %H:%M'), '99 bag manifest errors.']]
         self.assertEqual(result, expected, "Problem with test for not valid, bag manifest")
 
     def test_not_valid_fixity_changed(self):
@@ -78,9 +95,12 @@ class MyTestCase(unittest.TestCase):
 
         # Verifies the fixity validation log CSV has the correct values.
         result = csv_to_list('fixity_validation_20241031.csv')
-        expected = [['Status', 'Collection', 'Accession', 'Accession_Path', 'Fixity_Type', 'Fixity', 'Valid', 'Result'],
-                    ['closed', 'c1', 'a1-er', 'path\\a1-er', 'Bag', 'a1-er_bag', 'False', 'Fixity changed from x to y.'],
-                    ['closed', 'c1', 'a2-er', 'path\\a2-er', 'Zip', 'a2-er_zip_md5.txt', 'False', 'Fixity changed from x to y.']]
+        expected = [['Status', 'Collection', 'Accession', 'Accession_Path', 'Fixity_Type', 'Fixity',
+                     'Valid', 'Valid_Time', 'Result'],
+                    ['closed', 'c1', 'a1-er', 'path\\a1-er', 'Bag', 'a1-er_bag',
+                     'False', datetime.now().strftime('%Y-%m-%d %H:%M'), 'Fixity changed from x to y.'],
+                    ['closed', 'c1', 'a2-er', 'path\\a2-er', 'Zip', 'a2-er_zip_md5.txt',
+                     'False', datetime.now().strftime('%Y-%m-%d %H:%M'), 'Fixity changed from x to y.']]
         self.assertEqual(result, expected, "Problem with test for not valid, fixity changed")
 
     def test_valid_bag_manifest(self):
@@ -90,9 +110,12 @@ class MyTestCase(unittest.TestCase):
 
         # Verifies the fixity validation log CSV has the correct values.
         result = csv_to_list('fixity_validation_20241031.csv')
-        expected = [['Status', 'Collection', 'Accession', 'Accession_Path', 'Fixity_Type', 'Fixity', 'Valid', 'Result'],
-                    ['closed', 'c1', 'a1-er', 'path\\a1-er', 'Bag', 'a1-er_bag', 'True', 'Valid (bag manifest)'],
-                    ['closed', 'c1', 'a2-er', 'path\\a2-er', 'Zip', 'a2-er_zip_md5.txt', 'True', 'Valid (bag manifest)']]
+        expected = [['Status', 'Collection', 'Accession', 'Accession_Path', 'Fixity_Type', 'Fixity',
+                     'Valid', 'Valid_Time', 'Result'],
+                    ['closed', 'c1', 'a1-er', 'path\\a1-er', 'Bag', 'a1-er_bag',
+                     'True', datetime.now().strftime('%Y-%m-%d %H:%M'), 'Valid (bag manifest)'],
+                    ['closed', 'c1', 'a2-er', 'path\\a2-er', 'Zip', 'a2-er_zip_md5.txt',
+                     'True', datetime.now().strftime('%Y-%m-%d %H:%M'), 'Valid (bag manifest)']]
         self.assertEqual(result, expected, "Problem with test for valid bag manifest")
 
 

--- a/validate_fixity.py
+++ b/validate_fixity.py
@@ -110,7 +110,8 @@ def fixity_validation_log(acc_dir):
     Accession_Path is the full path to the folder which contains the digital content.
     Fixity_Type is Bag or Zip and will be used to determine how to validate the accession, or None.
     Fixity is the name of the bag folder or zip md5 file with the fixity information, or None.
-    Valid is None and will be updated with True, False, or Skipped after validation.
+    Valid is None or has text if Result also has text.
+    Valid_Time is None for all.
     Result is None for accessions to validate, "Not an accession", or "No fixity".
 
     There are other folders frequently at the accession level, such as FITS files and copies for appraisal.
@@ -128,7 +129,8 @@ def fixity_validation_log(acc_dir):
     log_path = os.path.join(acc_dir, f"fixity_validation_log_{date.today().strftime('%Y-%m-%d')}.csv")
     with (open(log_path, 'w', newline='') as open_log):
         log_writer = csv.writer(open_log)
-        log_writer.writerow(['Status', 'Collection', 'Accession', 'Accession_Path', 'Fixity_Type', 'Fixity', 'Valid', 'Result'])
+        log_writer.writerow(['Status', 'Collection', 'Accession', 'Accession_Path', 'Fixity_Type', 'Fixity',
+                             'Valid', 'Valid_Time', 'Result'])
 
         # Navigates the input_directory to get information about each folder at the accession level and adds to the log.
         for status in os.listdir(acc_dir):
@@ -165,7 +167,8 @@ def fixity_validation_log(acc_dir):
                                     is_valid = 'Skipped'
                                     result = 'Not an accession'
                                 # Adds information for folder to the log.
-                                row = [status, collection, folder, accession_path, fixity_type, fixity, is_valid, result]
+                                row = [status, collection, folder, accession_path, fixity_type, fixity,
+                                       is_valid, None, result]
                                 log_writer.writerow(row)
 
 

--- a/validate_fixity.py
+++ b/validate_fixity.py
@@ -17,7 +17,7 @@ Returns:
 """
 import bagit
 import csv
-from datetime import date
+from datetime import date, datetime
 import hashlib
 import os
 import re
@@ -265,6 +265,11 @@ def update_fixity_validation_log(log_path, df, row, result):
     else:
         is_valid = False
     df.loc[row, 'Valid'] = is_valid
+
+    # Adds the time of validation (using the current time, when the log is updated just after validation) to log.
+    # This is used to update preservation logs if they had formatting errors and for stats on this process.
+    timestamp = datetime.now().strftime('%Y-%m-%d %H:%M')
+    df.loc[row, 'Valid_Time'] = timestamp
 
     # Saves the updated information to fixity_validation_log.csv, so if the script breaks,
     # the information is correct for all accessions prior to the break.


### PR DESCRIPTION
Add a column Valid_Result with a timestamp (YYYY-MM-DD HH:MM) to the fixity_validation_log.csv, both to be able to update preservation logs with the correct date when a log is not automatically updated and for collecting stats on how long this process runs to identify scenarios that need to be sped up.